### PR TITLE
Marks Mac module_test_ios to be flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -541,6 +541,7 @@ targets:
 
   - name: mac_module_test_ios
     builder: Mac module_test_ios
+    bringup: true // Flaky https://github.com/chunhtai/flutter/issues/87
     scheduler: luci
     type: devicelab
     runIf:


### PR DESCRIPTION
Issue link: https://github.com/chunhtai/flutter/issues/87

<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  name: abcd
}
-->
