### PR TITLE
Marks Mac module_test_ios to be not flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -655,7 +655,6 @@ targets:
 
   - name: Mac module_test_ios
     builder: Mac module_test_ios
-    bringup: true
     properties:
       tags: >
         ["devicelab","hostonly"]


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Mac module_test_ios"
}
-->
The test has been passing for 50 consecutive runs
Therefore, this test can be marked as not flaky