### PR TITLE
Marks Linux docs_test to be not flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1139,7 +1139,6 @@ targets:
 
   - name: Linux docs_test
     builder: Linux docs_test
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/84609
     presubmit: false
     properties:
       tags: >


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Linux docs_test"
}
-->
The issue Instance of 'Issue' has been closed, and the test has been passing for 50 consecutive runs
Therefore, this test can be marked as not flaky