### PR TITLE
Marks Mac_ios flutter_gallery__transition_perf_e2e_ios32 to be not flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1823,7 +1823,6 @@ targets:
 
   - name: Mac_ios flutter_gallery__transition_perf_e2e_ios32
     builder: Mac_ios flutter_gallery__transition_perf_e2e_ios32
-    bringup: true
     presubmit: false
     properties:
       tags: >


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Mac_ios flutter_gallery__transition_perf_e2e_ios32"
}
-->
The test has been passing for 50 consecutive runs
Therefore, this test can be marked as not flaky