### PR TITLE
Marks Mac_android microbenchmarks to be not flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1654,7 +1654,6 @@ targets:
 
   - name: Mac_android microbenchmarks
     builder: Mac_android microbenchmarks
-    bringup: true
     presubmit: false
     properties:
       tags: >


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Mac_android microbenchmarks"
}
-->
The test has been passing for 50 consecutive runs.
Therefore, this test can be marked as not flaky