### PR TITLE
Marks Mac_android microbenchmarks to be not flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1654,7 +1654,6 @@ targets:
 
   - name: Mac_android microbenchmarks
     builder: Mac_android microbenchmarks
-    bringup: true
     presubmit: false
     properties:
       tags: >


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Mac_android microbenchmarks"
}
-->
The test has been passing for [50 consecutive runs](https://dashboards.corp.google.com/flutter_check_prod_test_flakiness_status_dashboard?p=BUILDER_NAME:%22Mac_android%20microbenchmarks%22).
This test can be marked as not flaky