### PR TITLE
Marks Mac_ios native_ui_tests_ios32 to be not flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1976,7 +1976,6 @@ targets:
 
   - name: Mac_ios native_ui_tests_ios32
     builder: Mac_ios native_ui_tests_ios32
-    bringup: true
     presubmit: false
     properties:
       tags: >


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Mac_ios native_ui_tests_ios32"
}
-->
The test has been passing for [50 consecutive runs](https://dashboards.corp.google.com/flutter_check_prod_test_flakiness_status_dashboard?p=BUILDER_NAME:%22Mac_ios%20native_ui_tests_ios32%22).
This test can be marked as not flaky