### PR TITLE
Marks Linux android_defines_test to be flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1018,6 +1018,7 @@ targets:
     scheduler: luci
 
   - name: Linux android_defines_test
+    bringup: true # Flaky https://github.com/chunhtai/flutter/issues/163
     builder: Linux android_defines_test
     presubmit: false
     properties:


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Linux android_defines_test"
}
-->
Issue link: https://github.com/chunhtai/flutter/issues/163
