### PR TITLE
Marks Linux new_gallery__crane_perf to be flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1349,6 +1349,7 @@ targets:
     scheduler: luci
 
   - name: Linux new_gallery__crane_perf
+    bringup: true # Flaky https://github.com/chunhtai/flutter/issues/167
     builder: Linux new_gallery__crane_perf
     presubmit: false
     properties:


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Linux new_gallery__crane_perf"
}
-->
Issue link: https://github.com/chunhtai/flutter/issues/167
