### PR TITLE
Marks Linux flutter_gallery__start_up to be flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1195,6 +1195,7 @@ targets:
     scheduler: luci
 
   - name: Linux flutter_gallery__start_up
+    bringup: true # Flaky https://github.com/chunhtai/flutter/issues/169
     builder: Linux flutter_gallery__start_up
     presubmit: false
     properties:


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Linux flutter_gallery__start_up"
}
-->
Issue link: https://github.com/chunhtai/flutter/issues/169
