### PR TITLE
Marks Linux flutter_gallery__memory_nav to be flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1187,6 +1187,7 @@ targets:
     scheduler: luci
 
   - name: Linux flutter_gallery__memory_nav
+    bringup: true # Flaky https://github.com/chunhtai/flutter/issues/172
     builder: Linux flutter_gallery__memory_nav
     presubmit: false
     properties:


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Linux flutter_gallery__memory_nav"
}
-->
Issue link: https://github.com/chunhtai/flutter/issues/172
