### PR TITLE
Marks Linux cubic_bezier_perf__e2e_summary to be flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1114,6 +1114,7 @@ targets:
     scheduler: luci
 
   - name: Linux cubic_bezier_perf__e2e_summary
+    bringup: true # Flaky https://github.com/chunhtai/flutter/issues/175
     builder: Linux cubic_bezier_perf__e2e_summary
     presubmit: false
     properties:


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Linux cubic_bezier_perf__e2e_summary"
}
-->
Issue link: https://github.com/chunhtai/flutter/issues/175
