### PR TITLE
Marks Linux flutter_gallery__transition_perf_with_semantics to be flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1220,6 +1220,7 @@ targets:
     scheduler: luci
 
   - name: Linux flutter_gallery__transition_perf_with_semantics
+    bringup: true # Flaky https://github.com/chunhtai/flutter/issues/182
     builder: Linux flutter_gallery__transition_perf_with_semantics
     presubmit: false
     properties:


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Linux flutter_gallery__transition_perf_with_semantics"
}
-->
Issue link: https://github.com/chunhtai/flutter/issues/182
