### PR TITLE
Marks Linux_android flutter_gallery__transition_perf_e2e to be unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -696,7 +696,6 @@ targets:
 
   - name: Linux test_ownership
     recipe: infra/test_ownership
-    bringup: true
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Linux_android flutter_gallery__transition_perf_e2e"
}
-->
The test has been passing for [50 consecutive runs](https://dashboards.corp.google.com/flutter_check_prod_test_flakiness_status_dashboard?p=BUILDER_NAME:%22Linux_android%20flutter_gallery__transition_perf_e2e%22).
This test can be marked as unflaky.
