### PR TITLE
Marks Linux test_ownership to be unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -248,7 +248,6 @@ targets:
 
   - name: Linux ci_yaml flutter roller
     recipe: infra/ci_yaml
-    bringup: true
     timeout: 30
     properties:
       tags: >


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Linux test_ownership"
}
-->
The test has been passing for [50 consecutive runs](https://dashboards.corp.google.com/flutter_check_prod_test_flakiness_status_dashboard?p=BUILDER_NAME:%22Linux%20test_ownership%22).
This test can be marked as unflaky.
